### PR TITLE
Fix mock-login pagination

### DIFF
--- a/app/routes/mock-login.js
+++ b/app/routes/mock-login.js
@@ -6,6 +6,12 @@ export default class MockLoginRoute extends Route {
   @service store;
   @service session;
 
+  queryParams = {
+    page: {
+      refreshModel: true,
+    },
+  };
+
   beforeModel() {
     this.session.prohibitAuthentication('index');
   }


### PR DESCRIPTION
The pagination on the mock-login was broken. Navigating to another page would not actually load a new page. This change fixes that issue, but also fixes another issue. After clicking the administrative unit to log in with, that the index page would load with the sidebar, but the mock-login page would still be displayed on the right.

This fixes issue https://github.com/lblod/frontend-dashboard/issues/8.