### PR TITLE
[DL-5913] Add ACM/IDM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,16 @@ To include in a semantic.works stack, include the following in docker-compose.ym
     restart: always
 ```
 
-In order to be able to log in with mu-login in the dashboard, you should include the mu-login-service in your docker-compose.yml:
+
+### Authentication methods
+
+The dashboard supports different methods of authentication. The default login route can be configured by setting the `EMBER_LOGIN_ROUTE` environment variable.
+
+#### `login` (default)
+
+This is the default method, so the `EMBER_LOGIN_ROUTE` variable doesn't need to be set.
+
+In order to be able to log in with mu-login in the dashboard, you should include the [mu-login-service](https://github.com/mu-semtech/login-service) in your docker-compose.yml:
 ```
   login:
     image: semtech/mu-login-service:2.9.1
@@ -66,6 +75,34 @@ dispatcher.ex should contain the following rule in order to get ember-mu-login w
 match "/sessions/*path", %{ accept: %{json: true} } do
     Proxy.forward conn, path, "http://login/sessions/"
 end
+```
+
+### `mock-login`
+The `mock-login` route needs the [mock-login-service](`https://github.com/lblod/mock-login-service`). Follow the instructions in the readme.
+
+```yml
+  dashboard:
+    #...
+    environment:
+      EMBER_LOGIN_ROUTE: "mock-login"
+```
+### `acmidm-login`
+The `acmidm-login` route needs the [acmidm-login-service](https://github.com/lblod/acmidm-login-service). Follow the instructions in the readme.
+
+It also requires some extra environment variables in the frontend:
+
+> The code snippet contains example values, adjust these based on your environment
+
+```yml
+  dashboard:
+    #...
+    environment:
+      EMBER_LOGIN_ROUTE: "acmidm-login"
+      EMBER_ACMIDM_CLIENT_ID: "client-id" 
+      EMBER_ACMIDM_BASE_URL: "https://authenticatie.vlaanderen.be/op/v1/auth"
+      EMBER_ACMIDM_REDIRECT_URL: "https://your-dashboard-domein/authorization/callback" 
+      EMBER_ACMIDM_LOGOUT_URL: "https://authenticatie.vlaanderen.be/op/v1/logout"
+      EMBER_ACMIDM_SCOPE: "openid rrn vo profile"
 ```
 
 ## Further Reading / Useful Links

--- a/app/controllers/acmidm-callback.js
+++ b/app/controllers/acmidm-callback.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default class AcmidmCallbackController extends Controller {
+  queryParams = ['code'];
+}

--- a/app/router.js
+++ b/app/router.js
@@ -9,6 +9,9 @@ export default class Router extends EmberRouter {
 Router.map(function () {
   this.route('mock-login');
   this.route('login');
+  this.route('acmidm-login');
+  this.route('acmidm-callback', { path: '/authorization/callback' });
+
   this.route('reports');
   this.route('errors');
   this.route('jobs', function () {

--- a/app/routes/acmidm-callback.js
+++ b/app/routes/acmidm-callback.js
@@ -1,0 +1,25 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+
+export default class AcmidmCallbackRoute extends Route {
+  @service session;
+
+  beforeModel() {
+    this.session.prohibitAuthentication('index');
+  }
+
+  async model({ code }) {
+    if (code) {
+      try {
+        await this.session.authenticate('authenticator:acm-idm', code);
+      } catch (error) {
+        throw new Error(
+          'Something went wrong while authenticating the user in the backend. The token might be expired.',
+          { cause: error },
+        );
+      }
+    } else {
+      throw new Error('Missing authorization token');
+    }
+  }
+}

--- a/app/routes/acmidm-login.js
+++ b/app/routes/acmidm-login.js
@@ -1,0 +1,32 @@
+import Route from '@ember/routing/route';
+import { service } from '@ember/service';
+import buildUrlFromConfig from '@lblod/ember-acmidm-login/utils/build-url-from-config';
+import ENV from 'frontend-dashboard/config/environment';
+
+export default class AcmidmLoginRoute extends Route {
+  @service session;
+  @service router;
+
+  beforeModel() {
+    if (this.session.prohibitAuthentication('index')) {
+      if (isValidAcmidmConfig(ENV.acmidm)) {
+        // We do the transition in the `routeDidChange` event because it is the only place I've found where the browser history has been correctly updated.
+        // The Route hooks run too soon, which means the previous history entry would be replaced instead.
+        this.router.on('routeDidChange', () => {
+          window.location.replace(buildUrlFromConfig(ENV.acmidm));
+        });
+      } else {
+        throw new Error('Missing ACM/IDM config');
+      }
+    }
+  }
+}
+
+function isValidAcmidmConfig(acmidmConfig) {
+  return Object.values(acmidmConfig).every(
+    (value) =>
+      typeof value === 'string' &&
+      value.trim() !== '' &&
+      !value.startsWith('{{'),
+  );
+}

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -2,10 +2,32 @@ import SessionService from 'ember-simple-auth/services/session';
 import ENV from 'frontend-dashboard/config/environment';
 
 export default class AppSessionService extends SessionService {
+  get isAcmIdmSession() {
+    if (!this.isAuthenticated) {
+      return false;
+    }
+
+    return this.data.authenticated.authenticator === 'authenticator:acm-idm';
+  }
+
   requireAuthentication(transition) {
     const loginRoute =
       ENV['routes'].login !== '{{LOGIN_ROUTE}}' ? ENV['routes'].login : 'login';
 
     return super.requireAuthentication(transition, loginRoute);
+  }
+
+  invalidate() {
+    // We store the flag here since the data is cleared before the handleInvalidation method is called.
+    this.wasAcmIdmSession = this.isAcmIdmSession;
+    super.invalidate(...arguments);
+  }
+
+  handleInvalidation(logoutUrl) {
+    if (this.wasAcmIdmSession) {
+      logoutUrl = ENV.acmidm.logoutUrl;
+    }
+
+    super.handleInvalidation(logoutUrl);
   }
 }

--- a/app/templates/acmidm-callback-loading.hbs
+++ b/app/templates/acmidm-callback-loading.hbs
@@ -1,0 +1,5 @@
+{{page-title (t "acmidm-login.logging-in")}}
+
+<AuLoader class="au-o-region-large">
+  {{t "acmidm-login.logging-in"}}
+</AuLoader>

--- a/app/templates/acmidm-login.hbs
+++ b/app/templates/acmidm-login.hbs
@@ -1,0 +1,5 @@
+{{page-title (t "acmidm-login.redirecting")}}
+
+<AuLoader class="au-o-region-large">
+  {{t "acmidm-login.redirecting"}}
+</AuLoader>

--- a/config/environment.js
+++ b/config/environment.js
@@ -21,6 +21,13 @@ module.exports = function (environment) {
     routes: {
       login: '{{LOGIN_ROUTE}}',
     },
+    acmidm: {
+      clientId: '{{ACMIDM_CLIENT_ID}}',
+      baseUrl: '{{ACMIDM_BASE_URL}}',
+      redirectUrl: '{{ACMIDM_REDIRECT_URL}}',
+      logoutUrl: '{{ACMIDM_LOGOUT_URL}}',
+      scope: '{{ACMIDM_SCOPE}}',
+    },
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@embroider/webpack": "^4.1.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
+        "@lblod/ember-acmidm-login": "^2.1.0",
         "@lblod/ember-mock-login": "^0.10.0",
         "@warp-drive/build-config": "^0.0.2",
         "broccoli-asset-rev": "^3.0.0",
@@ -7042,6 +7043,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lblod/ember-acmidm-login": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-acmidm-login/-/ember-acmidm-login-2.1.0.tgz",
+      "integrity": "sha512-Np35j6zvaoNgfE1IeTCn5jGFbjCvhTnp8FwbzEr59bl0SV0fd2YZxCNRTkRR86NLYc9/USfHJp/dQ/fqPaee1Q==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/addon-shim": "^1.0.0"
+      },
+      "peerDependencies": {
+        "ember-simple-auth": "4.x || 5.x || 6.x"
       }
     },
     "node_modules/@lblod/ember-mock-login": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@embroider/webpack": "^4.1.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
+    "@lblod/ember-acmidm-login": "^2.1.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@warp-drive/build-config": "^0.0.2",
     "broccoli-asset-rev": "^3.0.0",

--- a/translations/en-US.yaml
+++ b/translations/en-US.yaml
@@ -7,6 +7,9 @@ login:
   username: Username
   password: Password
   submit: Log In
+acmidm-login:
+  redirecting: Redirecting
+  logging-in: Logging in
 jobs:
   general:
     reset-filters: "Reset all filters"

--- a/translations/nl-BE.yml
+++ b/translations/nl-BE.yml
@@ -7,6 +7,9 @@ login:
   username: Gebruikersnaam
   password: Wachtwoord
   submit: Inloggen
+acmidm-login:
+  redirecting: Aan het doorverwijzen
+  logging-in: Aan het aanmelden
 jobs:
   general:
     reset-filters: "Filters verwijderen"
@@ -94,4 +97,3 @@ jobs:
     data:
       nodata: "Geen grafen gevonden"
       uri: "URI"
-


### PR DESCRIPTION
This adds a new acmidm-login route that can be used instead of the login and mock-login routes.

**To test this locally:**

- Generate ssl certificates: 
`mkcert -install -cert-file ./ssl/server.crt -key-file ./ssl/server.key localhost loket.lblod.info`
More info in [this guide](https://mainmatter.com/blog/2022/09/22/selfsigned-certificates-for-development/).
- edit `/etc/hosts` so `loket.lblod.info` maps to your local machine
- configure the login service of your local app-digitaal-loket repo so it matches the setup from loket QA
- edit the `config/environment.js` file and override all the `{{ACMIDM_*}}` variables with the data from loket QA. (Maybe there are ways to do this with docker-compose and build: ? but I haven't tried it)
- run ember serve on port 443 and use the --ssl argument: `npm start -- --port 443 --ssl --proxy http://localhost:9000` (You might need to run this with `sudo`).
- Go to `https://loket.lblod.info/acmidm-login` (or set the default route to `acmidm-login` in config/environment.js)
- Log in with ACM/IDM (you need to have access to the Loket QA ACM/IDM environment)
- You should get redirected back to the app and see the dashboard