### PR TITLE
Consistent date formatting

### DIFF
--- a/app/helpers/format-datetime.js
+++ b/app/helpers/format-datetime.js
@@ -1,10 +1,10 @@
 import { format } from 'date-fns';
 
-export default function formatPlainDate(datetime, formatString) {
+export default function formatPlainDate(datetime) {
   if (!(datetime instanceof Date)) return '';
 
   try {
-    return format(datetime, formatString);
+    return format(datetime, 'dd/MM/yyyy HH:mm:ss');
   } catch (e) {
     console.error(e);
     return '';

--- a/app/templates/errors.hbs
+++ b/app/templates/errors.hbs
@@ -62,7 +62,7 @@
       <td>{{logEntry.logSource.label}}</td>
       <td>{{last-part-uri logEntry.className}}</td>
       <td>{{logEntry.message}}</td>
-      <td>{{format-plain-date logEntry.datetime 'd MMMM yyyy, HH:mm'}}</td>
+      <td>{{format-datetime logEntry.datetime}}</td>
       <td>{{logEntry.specificInformation}}</td>
     </c.body>
   </t.content>

--- a/app/templates/jobs/details.hbs
+++ b/app/templates/jobs/details.hbs
@@ -41,11 +41,11 @@
       </li>
       <li class="au-o-grid__item au-u-1-2 au-u-1-6@medium">
         <AuLabel>{{t "jobs.details.created"}}</AuLabel>
-         {{format-date this.model.created 'dd/MM/yyyy HH:mm:ss'}}
+         {{format-datetime this.model.created}}
       </li>
       <li class="au-o-grid__item au-u-1-2 au-u-1-6@medium">
         <AuLabel>{{t "jobs.details.modified"}}</AuLabel>
-        {{format-date this.model.modified 'dd/MM/yyyy HH:mm:ss'}}
+        {{format-datetime this.model.modified}}
       </li>
       <li class="au-o-grid__item au-u-1-2 au-u-1-6@medium">
         <AuLabel>{{t "jobs.details.status"}}</AuLabel>

--- a/app/templates/jobs/details/index.hbs
+++ b/app/templates/jobs/details/index.hbs
@@ -30,7 +30,7 @@
           {{row.uri}}
         </td>
         <td>
-          {{format-date row.created 'dd/MM/yyyy HH:mm:ss'}}
+          {{format-datetime row.created}}
         </td>
         <td class="au-u-visible-small-up au-word-wrap">
           {{row.operation}}

--- a/app/templates/jobs/index.hbs
+++ b/app/templates/jobs/index.hbs
@@ -60,10 +60,10 @@
           {{row.uri}}
         </td>
         <td>
-          {{format-date row.created 'dd/MM/yyyy HH:mm:ss'}}
+          {{format-datetime row.created}}
         </td>
         <td class="au-u-visible-small-up">
-          {{format-date row.modified 'dd/MM/yyyy HH:mm:ss'}}
+          {{format-datetime row.modified}}
         </td>
         <td class="au-u-visible-medium-up">
           {{row.creator}}

--- a/app/templates/jobs/task.hbs
+++ b/app/templates/jobs/task.hbs
@@ -36,11 +36,11 @@
       </li>
       <li class="au-o-grid__item au-u-1-2 au-u-1-6@medium">
         <AuLabel>{{t "jobs.tasks.created"}}</AuLabel>
-         {{format-date this.model.created 'dd/MM/yyyy HH:mm:ss'}}
+         {{format-datetime this.model.created}}
       </li>
       <li class="au-o-grid__item au-u-1-2 au-u-1-6@medium">
         <AuLabel>{{t "jobs.tasks.modified"}}</AuLabel>
-        {{format-date this.model.modified 'dd/MM/yyyy HH:mm:ss'}}
+        {{format-datetime this.model.modified}}
       </li>
       <li class="au-o-grid__item au-u-1-2 au-u-1-6@medium">
         <AuLabel>{{t "jobs.tasks.status"}}</AuLabel>

--- a/app/templates/jobs/task/input-containers-files.hbs
+++ b/app/templates/jobs/task/input-containers-files.hbs
@@ -34,7 +34,7 @@
           {{row.humanReadableSize}}
         </td>
         <td>
-          {{format-date row.created 'dd/MM/yyyy HH:mm:ss'}}
+          {{format-datetime row.created}}
         </td>
         <td class="au-u-visible-small-up">
           <AuLinkExternal

--- a/app/templates/jobs/task/results-containers-files.hbs
+++ b/app/templates/jobs/task/results-containers-files.hbs
@@ -34,7 +34,7 @@
           {{row.humanReadableSize}}
         </td>
         <td>
-          {{format-date row.created 'dd/MM/yyyy HH:mm:ss'}}
+          {{format-datetime row.created}}
         </td>
         <td class="au-u-visible-small-up">
           <AuLinkExternal

--- a/app/templates/reports.hbs
+++ b/app/templates/reports.hbs
@@ -30,7 +30,7 @@
       <c.body as |row|>
         <td>{{row.title}}</td>
         <td>{{row.description}}</td>
-        <td>{{row.created}}</td>
+        <td>{{format-datetime row.created}}</td>
         <td>
           <AuLinkExternal
             href='/files/{{row.file.id}}/download'


### PR DESCRIPTION
Some dates were either not formatted or in a different way (without a specific reason), so this makes everything more consistent throughout the app.

This also fixes an issue where the jobs table page didn't show the time anymore since we forgot to move the custom `format-date` helper the engine was using when we inlined it. That helper was overriding the one from `ember-intl` so that's why we didn't see a build error when it was missing.